### PR TITLE
Add Flutter skeleton for expenses tracker

### DIFF
--- a/coinbag_flutter/README.md
+++ b/coinbag_flutter/README.md
@@ -1,0 +1,13 @@
+# CoinBag Flutter
+
+A Flutter-based expenses tracker supporting iOS and Android.
+
+## Features
+- Dashboard with the latest expenses
+- Configurable expenses list
+- Bank account linking and sync
+- CSV import/export
+- Multiple accounts, deposits and cards
+- Debit and credit balance tracking
+- Quick expense entry
+- Cloud sync stub

--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'screens/dashboard_screen.dart';
+import 'screens/expenses_list_screen.dart';
+import 'screens/add_expense_screen.dart';
+import 'screens/account_screen.dart';
+
+void main() {
+  runApp(const CoinBagApp());
+}
+
+class CoinBagApp extends StatelessWidget {
+  const CoinBagApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'CoinBag',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const HomePage(),
+    );
+  }
+}
+
+class HomePage extends StatefulWidget {
+  const HomePage({Key? key}) : super(key: key);
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _index = 0;
+
+  final _screens = const [
+    DashboardScreen(),
+    ExpensesListScreen(),
+    AddExpenseScreen(),
+    AccountScreen(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _screens[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: (i) => setState(() => _index = i),
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Expenses'),
+          BottomNavigationBarItem(icon: Icon(Icons.add), label: 'Add'),
+          BottomNavigationBarItem(icon: Icon(Icons.account_balance), label: 'Accounts'),
+        ],
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/models/account.dart
+++ b/coinbag_flutter/lib/models/account.dart
@@ -1,0 +1,13 @@
+class Account {
+  final String id;
+  final String name;
+  double debitBalance;
+  double creditBalance;
+
+  Account({
+    required this.id,
+    required this.name,
+    this.debitBalance = 0,
+    this.creditBalance = 0,
+  });
+}

--- a/coinbag_flutter/lib/models/expense.dart
+++ b/coinbag_flutter/lib/models/expense.dart
@@ -1,0 +1,15 @@
+class Expense {
+  final String id;
+  final String description;
+  final double amount;
+  final DateTime date;
+  final String accountId;
+
+  Expense({
+    required this.id,
+    required this.description,
+    required this.amount,
+    required this.date,
+    required this.accountId,
+  });
+}

--- a/coinbag_flutter/lib/screens/account_screen.dart
+++ b/coinbag_flutter/lib/screens/account_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class AccountScreen extends StatelessWidget {
+  const AccountScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Accounts')),
+      body: const Center(
+        child: Text('Bank linking and account details'),
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/add_expense_screen.dart
+++ b/coinbag_flutter/lib/screens/add_expense_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class AddExpenseScreen extends StatelessWidget {
+  const AddExpenseScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Expense')),
+      body: const Center(
+        child: Text('Form to add a new expense'),
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/dashboard_screen.dart
+++ b/coinbag_flutter/lib/screens/dashboard_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class DashboardScreen extends StatelessWidget {
+  const DashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: const Center(
+        child: Text('Latest expenses appear here'),
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/expenses_list_screen.dart
+++ b/coinbag_flutter/lib/screens/expenses_list_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ExpensesListScreen extends StatelessWidget {
+  const ExpensesListScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Expenses')),
+      body: ListView(
+        children: const [
+          ListTile(title: Text('Sample expense 1'), subtitle: Text('\$20')),
+          ListTile(title: Text('Sample expense 2'), subtitle: Text('\$12')),
+        ],
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/services/bank_sync_service.dart
+++ b/coinbag_flutter/lib/services/bank_sync_service.dart
@@ -1,0 +1,9 @@
+class BankSyncService {
+  Future<void> linkBankAccount() async {
+    // TODO: Implement real bank linking
+  }
+
+  Future<void> syncTransactions() async {
+    // TODO: Fetch transactions from linked bank
+  }
+}

--- a/coinbag_flutter/lib/services/cloud_sync_service.dart
+++ b/coinbag_flutter/lib/services/cloud_sync_service.dart
@@ -1,0 +1,9 @@
+class CloudSyncService {
+  Future<void> uploadData() async {
+    // TODO: implement cloud upload
+  }
+
+  Future<void> downloadData() async {
+    // TODO: implement cloud download
+  }
+}

--- a/coinbag_flutter/lib/services/csv_service.dart
+++ b/coinbag_flutter/lib/services/csv_service.dart
@@ -1,0 +1,14 @@
+import 'package:csv/csv.dart';
+import '../models/expense.dart';
+
+class CsvService {
+  String exportCsv(List<Expense> expenses) {
+    final rows = expenses.map((e) => [e.date.toIso8601String(), e.description, e.amount]).toList();
+    return const ListToCsvConverter().convert(rows);
+  }
+
+  List<Expense> importCsv(String data) {
+    final rows = const CsvToListConverter().convert(data);
+    return rows.map((r) => Expense(id: '', description: r[1], amount: r[2], date: DateTime.parse(r[0]), accountId: '')).toList();
+  }
+}

--- a/coinbag_flutter/pubspec.yaml
+++ b/coinbag_flutter/pubspec.yaml
@@ -1,0 +1,11 @@
+name: coinbag_flutter
+version: 0.1.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  csv: ^5.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter project skeleton under `coinbag_flutter`
- add models for expenses and accounts
- stub screens for dashboard, expenses list, add expense and account management
- provide placeholder services for bank sync, CSV import/export and cloud sync

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f5d869ea08320a83c35d780b0746b