### PR TITLE
Add Supabase API service

### DIFF
--- a/coinbag_flutter/README.md
+++ b/coinbag_flutter/README.md
@@ -10,7 +10,29 @@ A Flutter-based expenses tracker supporting iOS and Android.
 - Multiple accounts, deposits and cards
 - Debit and credit balance tracking
 - Quick expense entry
-- Cloud sync stub
+- Cloud sync via Supabase
+- Supabase-backed API for expenses and accounts
+
+## Configuration
+
+Set the following environment variables before running the app:
+
+```
+SUPABASE_URL=your-project-url
+SUPABASE_ANON_KEY=public-anon-key
+```
+
+These are required for the app to connect to your Supabase backend.
+
+## Supabase API
+
+The app communicates with Supabase for:
+
+- Fetching dashboard data
+- Paginated expenses listing
+- Adding, removing and editing expenses
+- Managing accounts
+- Tracking bank syncs
 
 ## Running tests
 

--- a/coinbag_flutter/lib/services/cloud_sync_service.dart
+++ b/coinbag_flutter/lib/services/cloud_sync_service.dart
@@ -1,9 +1,35 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/expense.dart';
+
 class CloudSyncService {
-  Future<void> uploadData() async {
-    // TODO: implement cloud upload
+  final SupabaseClient _client;
+
+  CloudSyncService({required String supabaseUrl, required String supabaseAnonKey})
+      : _client = SupabaseClient(supabaseUrl, supabaseAnonKey);
+
+  Future<void> uploadData(List<Expense> expenses) async {
+    final rows = expenses
+        .map((e) => {
+              'id': e.id,
+              'description': e.description,
+              'amount': e.amount,
+              'date': e.date.toIso8601String(),
+              'account_id': e.accountId,
+            })
+        .toList();
+    await _client.from('expenses').upsert(rows);
   }
 
-  Future<void> downloadData() async {
-    // TODO: implement cloud download
+  Future<List<Expense>> downloadData() async {
+    final data = await _client.from('expenses').select<List<Map<String, dynamic>>>().order('date');
+    return data
+        .map((r) => Expense(
+              id: r['id'] as String,
+              description: r['description'] as String,
+              amount: (r['amount'] as num).toDouble(),
+              date: DateTime.parse(r['date'] as String),
+              accountId: r['account_id'] as String,
+            ))
+        .toList();
   }
 }

--- a/coinbag_flutter/lib/services/supabase_api_service.dart
+++ b/coinbag_flutter/lib/services/supabase_api_service.dart
@@ -1,0 +1,88 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../models/expense.dart';
+import '../models/account.dart';
+
+class SupabaseApiService {
+  final SupabaseClient _client;
+
+  SupabaseApiService({required String supabaseUrl, required String supabaseAnonKey})
+      : _client = SupabaseClient(supabaseUrl, supabaseAnonKey);
+
+  Future<Map<String, dynamic>> fetchDashboardInfo(String accountId) async {
+    final data = await _client
+        .from('dashboard_info')
+        .select<Map<String, dynamic>>()
+        .eq('account_id', accountId)
+        .single();
+    return data;
+  }
+
+  Future<List<Expense>> fetchExpenses({required String accountId, int page = 0, int pageSize = 20}) async {
+    final from = page * pageSize;
+    final to = from + pageSize - 1;
+    final data = await _client
+        .from('expenses')
+        .select<List<Map<String, dynamic>>>()
+        .eq('account_id', accountId)
+        .range(from, to)
+        .order('date', ascending: false);
+    return data.map(_mapExpense).toList();
+  }
+
+  Future<void> addExpense(Expense expense) async {
+    await _client.from('expenses').insert({
+      'id': expense.id,
+      'description': expense.description,
+      'amount': expense.amount,
+      'date': expense.date.toIso8601String(),
+      'account_id': expense.accountId,
+    });
+  }
+
+  Future<void> removeExpense(String id) async {
+    await _client.from('expenses').delete().eq('id', id);
+  }
+
+  Future<void> editExpense(Expense expense) async {
+    await _client.from('expenses').update({
+      'description': expense.description,
+      'amount': expense.amount,
+      'date': expense.date.toIso8601String(),
+      'account_id': expense.accountId,
+    }).eq('id', expense.id);
+  }
+
+  Future<void> addAccount(Account account) async {
+    await _client.from('accounts').insert({
+      'id': account.id,
+      'name': account.name,
+      'debit_balance': account.debitBalance,
+      'credit_balance': account.creditBalance,
+    });
+  }
+
+  Future<void> updateAccount(Account account) async {
+    await _client.from('accounts').update({
+      'name': account.name,
+      'debit_balance': account.debitBalance,
+      'credit_balance': account.creditBalance,
+    }).eq('id', account.id);
+  }
+
+  Future<void> addBankSync(String accountId, Map<String, dynamic> syncData) async {
+    await _client.from('bank_syncs').insert({
+      'account_id': accountId,
+      ...syncData,
+    });
+  }
+
+  Expense _mapExpense(Map<String, dynamic> r) {
+    return Expense(
+      id: r['id'] as String,
+      description: r['description'] as String,
+      amount: (r['amount'] as num).toDouble(),
+      date: DateTime.parse(r['date'] as String),
+      accountId: r['account_id'] as String,
+    );
+  }
+}

--- a/coinbag_flutter/pubspec.yaml
+++ b/coinbag_flutter/pubspec.yaml
@@ -6,6 +6,7 @@ dependencies:
   flutter:
     sdk: flutter
   csv: ^5.0.0
+  supabase_flutter: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,26 @@
+# CoinBag Product Requirements
+
+CoinBag is a cross platform expense tracker built with Flutter. The app allows users to keep track of their spending across multiple accounts and sync data with a Supabase backend.
+
+## Core Functionality
+
+- View dashboard summary of recent spending and balances
+- Browse expenses with pagination
+- Add, edit and remove expenses
+- Link bank accounts and sync transactions
+- Manage multiple accounts with separate balances
+- Export and import data via CSV
+- Sync data to the cloud via Supabase
+
+## Technical Overview
+
+All backend data is stored in Supabase. The app communicates with Supabase through `SupabaseApiService` which exposes methods for expenses, accounts and bank sync information. Authentication is handled externally and not covered in this document.
+
+## Tables
+
+- `expenses` – stores individual expenses
+- `accounts` – stores user accounts
+- `bank_syncs` – tracks connected bank providers
+- `dashboard_info` – materialized view or RPC providing dashboard totals
+
+Each table stores rows belonging to a specific user or account. See the planning document for additional planned tables and fields.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,20 @@
+# CoinBag Development Plan
+
+This document outlines planned functionality and upcoming milestones for the CoinBag project.
+
+## Near Term Goals
+
+1. **Authentication** – integrate user login with Supabase Auth.
+2. **Enhanced Dashboard** – display charts of spending over time and upcoming bills.
+3. **Rich Expense Entry** – support categories, tags and recurring expenses.
+4. **Improved Bank Sync** – background sync of transactions and balance updates.
+5. **Offline Support** – queue actions locally and sync when connectivity returns.
+
+## Longer Term Ideas
+
+- Push notifications for large transactions and low balances
+- Shared accounts with multiple users
+- Web and desktop versions of the app
+- Integration with budgeting tools
+
+This plan will evolve as development progresses. Completed items will be moved to the changelog and new tasks will be added.


### PR DESCRIPTION
## Summary
- implement `SupabaseApiService` covering dashboard, expenses, accounts and bank sync calls
- document Supabase API usage in README
- add PRD and planning docs

## Testing
- `./run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6143a4ec832087b4fde5a28d6c79