### PR TITLE
Configure Flutter web deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy Flutter Web
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'coinbag_flutter/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+      - name: Enable web platform
+        run: flutter create . --platforms=web
+        working-directory: coinbag_flutter
+      - name: Install dependencies
+        run: flutter pub get
+        working-directory: coinbag_flutter
+      - name: Build web
+        run: flutter build web --release
+        working-directory: coinbag_flutter
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: coinbag_flutter/build/web
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# CoinBag
+
+CoinBag is a personal finance tracker. This repository contains two separate
+implementations:
+
+- `CoinBag/` – the original iOS code written in Swift.
+- `coinbag_flutter/` – a Flutter rewrite that targets multiple platforms.
+
+## Web version
+
+A GitHub Actions workflow builds the Flutter project for the web and publishes
+the result to GitHub Pages. Once Pages is enabled for the repository the latest
+build will be available from the `gh-pages` branch.
+
+### Local build
+
+To build the web app locally you need the Flutter SDK installed.
+Run the following commands from the project root:
+
+```bash
+cd coinbag_flutter
+flutter create . --platforms=web   # only needed once
+flutter pub get
+flutter build web --release
+```
+
+The compiled output will appear in `coinbag_flutter/build/web`.


### PR DESCRIPTION
## Summary
- document overall project and web build steps
- add GitHub Actions workflow to build Flutter web and deploy to GitHub Pages

## Testing
- `./coinbag_flutter/run_tests.sh` *(fails: Flutter SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f653c6e008320b83698270ce21f28