### PR TITLE
Add Supabase authentication

### DIFF
--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -3,8 +3,14 @@ import 'screens/dashboard_screen.dart';
 import 'screens/expenses_list_screen.dart';
 import 'screens/add_expense_screen.dart';
 import 'screens/account_screen.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Supabase.initialize(
+    url: const String.fromEnvironment('SUPABASE_URL', defaultValue: ''),
+    anonKey: const String.fromEnvironment('SUPABASE_ANON_KEY', defaultValue: ''),
+  );
   runApp(const CoinBagApp());
 }
 

--- a/coinbag_flutter/lib/screens/account_screen.dart
+++ b/coinbag_flutter/lib/screens/account_screen.dart
@@ -1,14 +1,45 @@
 import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+import 'login_screen.dart';
 
-class AccountScreen extends StatelessWidget {
+class AccountScreen extends StatefulWidget {
   const AccountScreen({Key? key}) : super(key: key);
 
   @override
+  State<AccountScreen> createState() => _AccountScreenState();
+}
+
+class _AccountScreenState extends State<AccountScreen> {
+  final AuthService _auth = AuthService();
+
+  @override
   Widget build(BuildContext context) {
+    final user = _auth.currentUser;
     return Scaffold(
       appBar: AppBar(title: const Text('Accounts')),
-      body: const Center(
-        child: Text('Bank linking and account details'),
+      body: Center(
+        child: user == null
+            ? LoginScreen(
+                authService: _auth,
+                onLogin: () => setState(() {}),
+              )
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('Logged in as ${user.email}'),
+                  const SizedBox(height: 12),
+                  ElevatedButton(
+                    key: const Key('signOutButton'),
+                    onPressed: () async {
+                      await _auth.signOut();
+                      setState(() {});
+                    },
+                    child: const Text('Sign Out'),
+                  ),
+                  const SizedBox(height: 24),
+                  const Text('Bank linking and account details'),
+                ],
+              ),
       ),
     );
   }

--- a/coinbag_flutter/lib/screens/login_screen.dart
+++ b/coinbag_flutter/lib/screens/login_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import '../services/auth_service.dart';
+
+class LoginScreen extends StatefulWidget {
+  final AuthService authService;
+  final VoidCallback onLogin;
+  const LoginScreen({Key? key, required this.authService, required this.onLogin}) : super(key: key);
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _loading = false;
+  String? _error;
+
+  Future<void> _signIn() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await widget.authService.signIn(_emailController.text, _passwordController.text);
+      widget.onLogin();
+    } on AuthException catch (e) {
+      setState(() => _error = e.message);
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _signUp() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      await widget.authService.signUp(_emailController.text, _passwordController.text);
+      widget.onLogin();
+    } on AuthException catch (e) {
+      setState(() => _error = e.message);
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            key: const Key('emailField'),
+            controller: _emailController,
+            decoration: const InputDecoration(labelText: 'Email'),
+          ),
+          TextField(
+            key: const Key('passwordField'),
+            controller: _passwordController,
+            decoration: const InputDecoration(labelText: 'Password'),
+            obscureText: true,
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+            ),
+          const SizedBox(height: 12),
+          ElevatedButton(
+            key: const Key('loginButton'),
+            onPressed: _loading ? null : _signIn,
+            child: const Text('Login'),
+          ),
+          TextButton(
+            key: const Key('signupButton'),
+            onPressed: _loading ? null : _signUp,
+            child: const Text('Sign Up'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/coinbag_flutter/lib/services/auth_service.dart
+++ b/coinbag_flutter/lib/services/auth_service.dart
@@ -1,0 +1,19 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+class AuthService {
+  final SupabaseClient _client = Supabase.instance.client;
+
+  User? get currentUser => _client.auth.currentUser;
+
+  Future<AuthResponse> signUp(String email, String password) {
+    return _client.auth.signUp(email: email, password: password);
+  }
+
+  Future<AuthResponse> signIn(String email, String password) {
+    return _client.auth.signInWithPassword(email: email, password: password);
+  }
+
+  Future<void> signOut() {
+    return _client.auth.signOut();
+  }
+}

--- a/coinbag_flutter/test/ui_test.dart
+++ b/coinbag_flutter/test/ui_test.dart
@@ -26,10 +26,10 @@ void main() {
       expect(find.text('Form to add a new expense'), findsOneWidget);
     });
 
-    testWidgets('Account screen shows linking placeholder', (tester) async {
+    testWidgets('Account screen shows login form when signed out', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: AccountScreen()));
       expect(find.text('Accounts'), findsOneWidget);
-      expect(find.text('Bank linking and account details'), findsOneWidget);
+      expect(find.text('Login'), findsOneWidget);
     });
   });
 
@@ -56,6 +56,6 @@ void main() {
     await tester.tap(find.byIcon(Icons.account_balance));
     await tester.pumpAndSettle();
     expect(find.text('Accounts'), findsOneWidget);
-    expect(find.text('Bank linking and account details'), findsOneWidget);
+    expect(find.text('Login'), findsOneWidget);
   });
 }

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,13 +2,16 @@
 
 This document outlines planned functionality and upcoming milestones for the CoinBag project.
 
-## Near Term Goals
+## Open Items
 
-1. **Authentication** – integrate user login with Supabase Auth.
-2. **Enhanced Dashboard** – display charts of spending over time and upcoming bills.
-3. **Rich Expense Entry** – support categories, tags and recurring expenses.
-4. **Improved Bank Sync** – background sync of transactions and balance updates.
-5. **Offline Support** – queue actions locally and sync when connectivity returns.
+- **Enhanced Dashboard** – display charts of spending over time and upcoming bills.
+- **Rich Expense Entry** – support categories, tags and recurring expenses.
+- **Improved Bank Sync** – background sync of transactions and balance updates.
+- **Offline Support** – queue actions locally and sync when connectivity returns.
+
+## Closed Items
+
+- **Authentication** – integrate user login with Supabase Auth.
 
 ## Longer Term Ideas
 


### PR DESCRIPTION
## Summary
- initialize Supabase in Flutter main
- add `AuthService` and login UI
- show login form in Account screen with sign out option
- update tests for new login behavior
- track closed/open items in `docs/plan.md`

## Testing
- `./run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6508326083208a3ec6b226ad16d3