### PR TITLE
Add premium IAP for multiple bank syncs

### DIFF
--- a/coinbag_flutter/README.md
+++ b/coinbag_flutter/README.md
@@ -6,6 +6,7 @@ A Flutter-based expenses tracker supporting iOS and Android.
 - Dashboard with the latest expenses
 - Configurable expenses list
 - Bank account linking and sync
+- Optional premium upgrade for multiple bank syncs
 - CSV import/export
 - Multiple accounts, deposits and cards
 - Debit and credit balance tracking

--- a/coinbag_flutter/lib/services/bank_sync_service.dart
+++ b/coinbag_flutter/lib/services/bank_sync_service.dart
@@ -1,6 +1,24 @@
+import 'iap_service.dart';
+
 class BankSyncService {
-  Future<void> linkBankAccount() async {
-    // TODO: Implement real bank linking
+  final IapService iapService;
+  final int freeLimit;
+
+  BankSyncService({required this.iapService, this.freeLimit = 1});
+
+  final List<String> _linkedAccounts = [];
+
+  List<String> get linkedAccounts => List.unmodifiable(_linkedAccounts);
+
+  /// Attempts to link a new bank account. Returns `true` if the account was
+  /// linked or `false` if the user has reached the free limit without premium.
+  Future<bool> linkBankAccount(String accountId) async {
+    if (!iapService.hasPremium && _linkedAccounts.length >= freeLimit) {
+      return false;
+    }
+    _linkedAccounts.add(accountId);
+    // TODO: Implement real bank linking with external provider
+    return true;
   }
 
   Future<void> syncTransactions() async {

--- a/coinbag_flutter/lib/services/iap_service.dart
+++ b/coinbag_flutter/lib/services/iap_service.dart
@@ -1,0 +1,11 @@
+class IapService {
+  bool _hasPremium = false;
+
+  bool get hasPremium => _hasPremium;
+
+  /// Simulates purchasing the premium upgrade.
+  Future<void> buyPremium() async {
+    // In a real app this would trigger the platform purchase flow.
+    _hasPremium = true;
+  }
+}

--- a/coinbag_flutter/test/bank_sync_service_test.dart
+++ b/coinbag_flutter/test/bank_sync_service_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:coinbag_flutter/services/bank_sync_service.dart';
+import 'package:coinbag_flutter/services/iap_service.dart';
+
+void main() {
+  group('BankSyncService', () {
+    test('limits linking without premium purchase', () async {
+      final iap = IapService();
+      final service = BankSyncService(iapService: iap);
+
+      expect(await service.linkBankAccount('acc1'), isTrue);
+      expect(await service.linkBankAccount('acc2'), isFalse);
+      expect(service.linkedAccounts.length, 1);
+
+      await iap.buyPremium();
+      expect(await service.linkBankAccount('acc2'), isTrue);
+      expect(service.linkedAccounts.length, 2);
+    });
+  });
+}

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -8,6 +8,7 @@ CoinBag is a cross platform expense tracker built with Flutter. The app allows u
 - Browse expenses with pagination
 - Add, edit and remove expenses
 - Link bank accounts and sync transactions
+- Premium users can link multiple banks
 - Manage multiple accounts with separate balances
 - Export and import data via CSV
 - Sync data to the cloud via Supabase

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -7,6 +7,7 @@ This document outlines planned functionality and upcoming milestones for the Coi
 - **Enhanced Dashboard** – display charts of spending over time and upcoming bills.
 - **Rich Expense Entry** – support categories, tags and recurring expenses.
 - **Improved Bank Sync** – background sync of transactions and balance updates.
+- **In-app Purchases** – unlock multiple bank syncs with a premium upgrade.
 - **Offline Support** – queue actions locally and sync when connectivity returns.
 
 ## Closed Items


### PR DESCRIPTION
## Summary
- introduce `IapService` stub
- gate bank linking through `BankSyncService`
- test bank sync purchase requirement
- note premium upgrade in docs

## Testing
- `coinbag_flutter/run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff53c53c48320bb6410ed32a6620c