### PR TITLE
Fix GitHub Pages workflow push permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,9 @@ on:
       - 'coinbag_flutter/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
   group: 'pages'
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- allow the GITHUB_TOKEN to push to the repo

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684007310f0c8320965ab71927828b67