### PR TITLE
Fix GitHub Pages build path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
         run: flutter pub get
         working-directory: coinbag_flutter
       - name: Build web
-        run: flutter build web --release
+        run: flutter build web --release --base-href /CoinBag/
         working-directory: coinbag_flutter
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Run the following commands from the project root:
 cd coinbag_flutter
 flutter create . --platforms=web   # only needed once
 flutter pub get
-flutter build web --release
+flutter build web --release --base-href /CoinBag/
 ```
 
 The compiled output will appear in `coinbag_flutter/build/web`.
+
+When deploying to GitHub Pages, specify the `--base-href` option so that
+asset paths are resolved relative to the repository name. If you deploy the
+web app at a different root path, adjust the value accordingly.


### PR DESCRIPTION
## Summary
- adjust GitHub Actions build step so Flutter emits assets with `/CoinBag/` prefix
- document the required `--base-href` option for local builds

## Testing
- `./coinbag_flutter/run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684009b711888320ba2c775e13d02e92