### PR TITLE
Apply vibrant expressive color scheme

### DIFF
--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -4,6 +4,7 @@ import 'screens/expenses_list_screen.dart';
 import 'screens/add_expense_screen.dart';
 import 'screens/account_screen.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -21,7 +22,7 @@ class CoinBagApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'CoinBag',
-      theme: ThemeData(primarySwatch: Colors.blue),
+      theme: lightTheme,
       home: const HomePage(),
     );
   }
@@ -50,6 +51,8 @@ class _HomePageState extends State<HomePage> {
       body: _screens[_index],
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _index,
+        selectedItemColor: Theme.of(context).colorScheme.primary,
+        unselectedItemColor: Theme.of(context).colorScheme.onSurfaceVariant,
         onTap: (i) => setState(() => _index = i),
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),

--- a/coinbag_flutter/lib/screens/dashboard_screen.dart
+++ b/coinbag_flutter/lib/screens/dashboard_screen.dart
@@ -57,7 +57,10 @@ class SpendingChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter: _LineChartPainter(data),
+      painter: _LineChartPainter(
+        data: data,
+        lineColor: Theme.of(context).colorScheme.primary,
+      ),
       child: Container(),
     );
   }
@@ -65,13 +68,14 @@ class SpendingChart extends StatelessWidget {
 
 class _LineChartPainter extends CustomPainter {
   final List<double> data;
-  _LineChartPainter(this.data);
+  final Color lineColor;
+  _LineChartPainter({required this.data, required this.lineColor});
 
   @override
   void paint(Canvas canvas, Size size) {
     if (data.isEmpty) return;
     final paint = Paint()
-      ..color = Colors.blue
+      ..color = lineColor
       ..strokeWidth = 2
       ..style = PaintingStyle.stroke;
 

--- a/coinbag_flutter/lib/screens/login_screen.dart
+++ b/coinbag_flutter/lib/screens/login_screen.dart
@@ -68,7 +68,10 @@ class _LoginScreenState extends State<LoginScreen> {
           if (_error != null)
             Padding(
               padding: const EdgeInsets.only(top: 8),
-              child: Text(_error!, style: const TextStyle(color: Colors.red)),
+              child: Text(
+                _error!,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
             ),
           const SizedBox(height: 12),
           ElevatedButton(

--- a/coinbag_flutter/lib/theme.dart
+++ b/coinbag_flutter/lib/theme.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+/// Light theme for CoinBag using a vibrant expressive color scheme.
+final ColorScheme _lightColorScheme = ColorScheme.fromSeed(
+  brightness: Brightness.light,
+  seedColor: Color(0xFF6750A4),
+);
+
+final ThemeData lightTheme = ThemeData(
+  useMaterial3: true,
+  colorScheme: _lightColorScheme,
+  appBarTheme: AppBarTheme(
+    backgroundColor: _lightColorScheme.primary,
+    foregroundColor: _lightColorScheme.onPrimary,
+  ),
+  scaffoldBackgroundColor: _lightColorScheme.background,
+);


### PR DESCRIPTION
## Summary
- introduce `lib/theme.dart` with expressive light color scheme
- use new theme in `main.dart`
- colorize bottom navigation via the theme
- paint dashboard chart with theme primary color
- show login errors with theme error color

## Testing
- `./run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840268f124c83209eaaefa16a324a36