### PR TITLE
Enforce auth flow with mock sign-in

### DIFF
--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -3,6 +3,7 @@ import 'screens/dashboard_screen.dart';
 import 'screens/expenses_list_screen.dart';
 import 'screens/add_expense_screen.dart';
 import 'screens/account_screen.dart';
+import 'screens/login_screen.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'theme.dart';
 
@@ -15,21 +16,39 @@ Future<void> main() async {
   runApp(const CoinBagApp());
 }
 
-class CoinBagApp extends StatelessWidget {
+class CoinBagApp extends StatefulWidget {
   const CoinBagApp({Key? key}) : super(key: key);
+
+  @override
+  State<CoinBagApp> createState() => _CoinBagAppState();
+}
+
+class _CoinBagAppState extends State<CoinBagApp> {
+  final AuthService _auth = AuthService();
+
+  void _refresh() => setState(() {});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'CoinBag',
       theme: lightTheme,
-      home: const HomePage(),
+      home: _auth.isLoggedIn
+          ? HomePage(authService: _auth, onLogout: _refresh)
+          : LoginScreen(
+              authService: _auth,
+              onLogin: _refresh,
+              allowSkip: true,
+            ),
     );
   }
 }
 
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  final AuthService authService;
+  final VoidCallback onLogout;
+  const HomePage({Key? key, required this.authService, required this.onLogout})
+      : super(key: key);
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -38,12 +57,21 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   int _index = 0;
 
-  final _screens = const [
-    DashboardScreen(),
-    ExpensesListScreen(),
-    AddExpenseScreen(),
-    AccountScreen(),
-  ];
+  late final List<Widget> _screens;
+
+  @override
+  void initState() {
+    super.initState();
+    _screens = [
+      const DashboardScreen(),
+      const ExpensesListScreen(),
+      const AddExpenseScreen(),
+      AccountScreen(
+        authService: widget.authService,
+        onLogout: widget.onLogout,
+      ),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/coinbag_flutter/lib/screens/account_screen.dart
+++ b/coinbag_flutter/lib/screens/account_screen.dart
@@ -3,36 +3,49 @@ import '../services/auth_service.dart';
 import 'login_screen.dart';
 
 class AccountScreen extends StatefulWidget {
-  const AccountScreen({Key? key}) : super(key: key);
+  final AuthService authService;
+  final VoidCallback onLogout;
+  const AccountScreen({Key? key, required this.authService, required this.onLogout}) : super(key: key);
 
   @override
   State<AccountScreen> createState() => _AccountScreenState();
 }
 
 class _AccountScreenState extends State<AccountScreen> {
-  final AuthService _auth = AuthService();
+  bool _loading = true;
 
   @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(milliseconds: 500))
+        .then((_) => setState(() => _loading = false));
+  }
+  @override
   Widget build(BuildContext context) {
-    final user = _auth.currentUser;
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    final loggedIn = widget.authService.isLoggedIn;
     return Scaffold(
       appBar: AppBar(title: const Text('Accounts')),
       body: Center(
-        child: user == null
+        child: !loggedIn
             ? LoginScreen(
-                authService: _auth,
+                authService: widget.authService,
                 onLogin: () => setState(() {}),
               )
             : Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text('Logged in as ${user.email}'),
+                  Text('Logged in as ${widget.authService.currentEmail ?? ''}') ,
                   const SizedBox(height: 12),
                   ElevatedButton(
                     key: const Key('signOutButton'),
                     onPressed: () async {
-                      await _auth.signOut();
-                      setState(() {});
+                      await widget.authService.signOut();
+                      widget.onLogout();
                     },
                     child: const Text('Sign Out'),
                   ),

--- a/coinbag_flutter/lib/screens/add_expense_screen.dart
+++ b/coinbag_flutter/lib/screens/add_expense_screen.dart
@@ -3,29 +3,43 @@ import 'package:flutter/material.dart';
 class AddExpenseScreen extends StatelessWidget {
   const AddExpenseScreen({Key? key}) : super(key: key);
 
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Add Expense')),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ListView(
-          children: const [
-            TextField(decoration: InputDecoration(labelText: 'Description')),
-            TextField(
-              decoration: InputDecoration(labelText: 'Amount'),
-              keyboardType: TextInputType.number,
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('Add Expense')),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: ListView(
+              children: const [
+                TextField(decoration: InputDecoration(labelText: 'Description')),
+                TextField(
+                  decoration: InputDecoration(labelText: 'Amount'),
+                  keyboardType: TextInputType.number,
+                ),
+                TextField(decoration: InputDecoration(labelText: 'Category')),
+                TextField(decoration: InputDecoration(labelText: 'Tags')),
+                TextField(
+                  decoration:
+                      InputDecoration(labelText: 'Recurring interval (days)'),
+                  keyboardType: TextInputType.number,
+                ),
+              ],
             ),
-            TextField(decoration: InputDecoration(labelText: 'Category')),
-            TextField(decoration: InputDecoration(labelText: 'Tags')),
-            TextField(
-              decoration:
-                  InputDecoration(labelText: 'Recurring interval (days)'),
-              keyboardType: TextInputType.number,
-            ),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/coinbag_flutter/lib/screens/dashboard_screen.dart
+++ b/coinbag_flutter/lib/screens/dashboard_screen.dart
@@ -20,32 +20,46 @@ class DashboardScreen extends StatelessWidget {
             dueDate: DateTime.now().add(const Duration(days: 12))),
       ];
 
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Dashboard')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: [
-          const Text(
-            'Spending Over Time',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('Dashboard')),
+          body: ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              const Text(
+                'Spending Over Time',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 200, child: SpendingChart(data: _spending)),
+              const SizedBox(height: 16),
+              const Text(
+                'Upcoming Bills',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              ..._upcomingBills.map(
+                (b) => ListTile(
+                  title: Text(b.description),
+                  subtitle: Text(
+                      '\$${b.amount.toStringAsFixed(2)} due ${b.dueDate.month}/${b.dueDate.day}/${b.dueDate.year}'),
+                ),
+              ),
+            ],
           ),
-          SizedBox(height: 200, child: SpendingChart(data: _spending)),
-          const SizedBox(height: 16),
-          const Text(
-            'Upcoming Bills',
-            style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
-          ),
-          ..._upcomingBills.map(
-            (b) => ListTile(
-              title: Text(b.description),
-              subtitle: Text(
-                  '\$${b.amount.toStringAsFixed(2)} due ${b.dueDate.month}/${b.dueDate.day}/${b.dueDate.year}'),
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/coinbag_flutter/lib/screens/expenses_list_screen.dart
+++ b/coinbag_flutter/lib/screens/expenses_list_screen.dart
@@ -3,16 +3,30 @@ import 'package:flutter/material.dart';
 class ExpensesListScreen extends StatelessWidget {
   const ExpensesListScreen({Key? key}) : super(key: key);
 
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Expenses')),
-      body: ListView(
-        children: const [
-          ListTile(title: Text('Sample expense 1'), subtitle: Text('\$20')),
-          ListTile(title: Text('Sample expense 2'), subtitle: Text('\$12')),
-        ],
-      ),
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('Expenses')),
+          body: ListView(
+            children: const [
+              ListTile(title: Text('Sample expense 1'), subtitle: Text('\$20')),
+              ListTile(title: Text('Sample expense 2'), subtitle: Text('\$12')),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/coinbag_flutter/lib/screens/login_screen.dart
+++ b/coinbag_flutter/lib/screens/login_screen.dart
@@ -5,7 +5,13 @@ import '../services/auth_service.dart';
 class LoginScreen extends StatefulWidget {
   final AuthService authService;
   final VoidCallback onLogin;
-  const LoginScreen({Key? key, required this.authService, required this.onLogin}) : super(key: key);
+  final bool allowSkip;
+  const LoginScreen({
+    Key? key,
+    required this.authService,
+    required this.onLogin,
+    this.allowSkip = false,
+  }) : super(key: key);
 
   @override
   State<LoginScreen> createState() => _LoginScreenState();
@@ -16,6 +22,12 @@ class _LoginScreenState extends State<LoginScreen> {
   final _passwordController = TextEditingController();
   bool _loading = false;
   String? _error;
+
+  Future<void> _skip() async {
+    setState(() => _loading = true);
+    await widget.authService.signInMock('demo@example.com');
+    widget.onLogin();
+  }
 
   Future<void> _signIn() async {
     setState(() {
@@ -83,7 +95,12 @@ class _LoginScreenState extends State<LoginScreen> {
             key: const Key('signupButton'),
             onPressed: _loading ? null : _signUp,
             child: const Text('Sign Up'),
-          )
+          ),
+          if (widget.allowSkip)
+            TextButton(
+              onPressed: _loading ? null : _skip,
+              child: const Text('Skip'),
+            )
         ],
       ),
     );

--- a/coinbag_flutter/lib/services/auth_service.dart
+++ b/coinbag_flutter/lib/services/auth_service.dart
@@ -2,8 +2,11 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 
 class AuthService {
   final SupabaseClient _client = Supabase.instance.client;
+  String? _mockEmail;
 
-  User? get currentUser => _client.auth.currentUser;
+  bool get isLoggedIn => _mockEmail != null || _client.auth.currentUser != null;
+
+  String? get currentEmail => _mockEmail ?? _client.auth.currentUser?.email;
 
   Future<AuthResponse> signUp(String email, String password) {
     return _client.auth.signUp(email: email, password: password);
@@ -13,7 +16,13 @@ class AuthService {
     return _client.auth.signInWithPassword(email: email, password: password);
   }
 
-  Future<void> signOut() {
-    return _client.auth.signOut();
+  Future<void> signInMock(String email) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    _mockEmail = email;
+  }
+
+  Future<void> signOut() async {
+    _mockEmail = null;
+    await _client.auth.signOut();
   }
 }


### PR DESCRIPTION
## Summary
- add optional skip login path with mock auth data
- require login before accessing the main app
- pass auth state to home and account screens
- show loading placeholders on all screens to mimic fetching

## Testing
- `bash coinbag_flutter/run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403123529c8320b989dbf3e88189b3