### PR TITLE
Adjust navigation and mock data

### DIFF
--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'screens/dashboard_screen.dart';
 import 'screens/expenses_list_screen.dart';
-import 'screens/add_expense_screen.dart';
 import 'screens/account_screen.dart';
 import 'screens/login_screen.dart';
 import 'services/auth_service.dart';
@@ -66,7 +65,6 @@ class _HomePageState extends State<HomePage> {
     _screens = [
       const DashboardScreen(),
       const ExpensesListScreen(),
-      const AddExpenseScreen(),
       AccountScreen(
         authService: widget.authService,
         onLogout: widget.onLogout,
@@ -86,7 +84,6 @@ class _HomePageState extends State<HomePage> {
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
           BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Expenses'),
-          BottomNavigationBarItem(icon: Icon(Icons.add), label: 'Add'),
           BottomNavigationBarItem(icon: Icon(Icons.account_balance), label: 'Accounts'),
         ],
       ),

--- a/coinbag_flutter/lib/screens/expenses_list_screen.dart
+++ b/coinbag_flutter/lib/screens/expenses_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'add_expense_screen.dart';
 
 class ExpensesListScreen extends StatelessWidget {
   const ExpensesListScreen({Key? key}) : super(key: key);
@@ -17,13 +18,24 @@ class ExpensesListScreen extends StatelessWidget {
             body: Center(child: CircularProgressIndicator()),
           );
         }
+        final items = List.generate(50, (i) {
+          final date = DateTime.now().subtract(Duration(days: i));
+          return ListTile(
+            title: Text('Expense ${i + 1}'),
+            subtitle: Text(
+                '\$${((i + 1) * 2).toStringAsFixed(2)} - ${date.month}/${date.day}/${date.year}'),
+          );
+        });
         return Scaffold(
           appBar: AppBar(title: const Text('Expenses')),
-          body: ListView(
-            children: const [
-              ListTile(title: Text('Sample expense 1'), subtitle: Text('\$20')),
-              ListTile(title: Text('Sample expense 2'), subtitle: Text('\$12')),
-            ],
+          body: ListView(children: items),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const AddExpenseScreen()),
+              );
+            },
+            child: const Icon(Icons.add),
           ),
         );
       },

--- a/coinbag_flutter/test/ui_test.dart
+++ b/coinbag_flutter/test/ui_test.dart
@@ -18,7 +18,7 @@ void main() {
     testWidgets('Expenses list screen shows sample data', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: ExpensesListScreen()));
       expect(find.text('Expenses'), findsOneWidget);
-      expect(find.text('Sample expense 1'), findsOneWidget);
+      expect(find.text('Expense 1'), findsOneWidget);
     });
 
     testWidgets('Add expense screen shows rich entry form', (tester) async {
@@ -48,10 +48,10 @@ void main() {
     await tester.tap(find.byIcon(Icons.list));
     await tester.pumpAndSettle();
     expect(find.text('Expenses'), findsWidgets);
-    expect(find.text('Sample expense 1'), findsOneWidget);
+    expect(find.text('Expense 1'), findsOneWidget);
 
-    // Navigate to Add screen
-    await tester.tap(find.byIcon(Icons.add));
+    // Open Add screen via action button
+    await tester.tap(find.byType(FloatingActionButton));
     await tester.pumpAndSettle();
     expect(find.text('Add Expense'), findsOneWidget);
     expect(find.text('Description'), findsOneWidget);


### PR DESCRIPTION
## Summary
- remove Add tab from bottom navigation
- add FloatingActionButton on the expenses list to open Add Expense screen
- populate expenses list with 50 mock entries
- update UI tests for new navigation

## Testing
- `bash coinbag_flutter/run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684038a37d6083209f845aacf94c25e1