### PR TITLE
Add settings page screens

### DIFF
--- a/coinbag_flutter/lib/main.dart
+++ b/coinbag_flutter/lib/main.dart
@@ -3,6 +3,7 @@ import 'screens/dashboard_screen.dart';
 import 'screens/expenses_list_screen.dart';
 import 'screens/account_screen.dart';
 import 'screens/login_screen.dart';
+import 'screens/settings/settings_screen.dart';
 import 'services/auth_service.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'theme.dart';
@@ -69,6 +70,7 @@ class _HomePageState extends State<HomePage> {
         authService: widget.authService,
         onLogout: widget.onLogout,
       ),
+      const SettingsScreen(),
     ];
   }
 
@@ -85,6 +87,7 @@ class _HomePageState extends State<HomePage> {
           BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
           BottomNavigationBarItem(icon: Icon(Icons.list), label: 'Expenses'),
           BottomNavigationBarItem(icon: Icon(Icons.account_balance), label: 'Accounts'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
         ],
       ),
     );

--- a/coinbag_flutter/lib/screens/settings/automatic_rules_screen.dart
+++ b/coinbag_flutter/lib/screens/settings/automatic_rules_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class AutomaticRulesScreen extends StatelessWidget {
+  const AutomaticRulesScreen({Key? key}) : super(key: key);
+
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final items = List.generate(
+          10,
+          (i) => ListTile(title: Text('Rule ${i + 1}')),
+        );
+        return Scaffold(
+          appBar: AppBar(title: const Text('Automatic Rules')),
+          body: ListView(children: items),
+        );
+      },
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/settings/category_settings_screen.dart
+++ b/coinbag_flutter/lib/screens/settings/category_settings_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class CategorySettingsScreen extends StatelessWidget {
+  const CategorySettingsScreen({Key? key}) : super(key: key);
+
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final items = List.generate(
+          10,
+          (i) => ListTile(title: Text('Category ${i + 1}')),
+        );
+        return Scaffold(
+          appBar: AppBar(title: const Text('Categories')),
+          body: ListView(children: items),
+        );
+      },
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/settings/settings_screen.dart
+++ b/coinbag_flutter/lib/screens/settings/settings_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'category_settings_screen.dart';
+import 'tag_settings_screen.dart';
+import 'automatic_rules_screen.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({Key? key}) : super(key: key);
+
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        return Scaffold(
+          appBar: AppBar(title: const Text('Settings')),
+          body: ListView(
+            children: [
+              ListTile(
+                title: const Text('Categories'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const CategorySettingsScreen(),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                title: const Text('Tags'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const TagSettingsScreen(),
+                    ),
+                  );
+                },
+              ),
+              ListTile(
+                title: const Text('Automatic Rules'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const AutomaticRulesScreen(),
+                    ),
+                  );
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/coinbag_flutter/lib/screens/settings/tag_settings_screen.dart
+++ b/coinbag_flutter/lib/screens/settings/tag_settings_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class TagSettingsScreen extends StatelessWidget {
+  const TagSettingsScreen({Key? key}) : super(key: key);
+
+  Future<void> _load() async {
+    await Future.delayed(const Duration(milliseconds: 500));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<void>(
+      future: _load(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final items = List.generate(
+          10,
+          (i) => ListTile(title: Text('Tag ${i + 1}')),
+        );
+        return Scaffold(
+          appBar: AppBar(title: const Text('Tags')),
+          body: ListView(children: items),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create SettingsScreen with links to category, tag and rule screens
- scaffold individual subpages under settings
- add Settings tab to main navigation

## Testing
- `./run_tests.sh` *(fails: Flutter SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_684044f945908320a62ab5aa320c252e