### PR TITLE
Add tag creation UI

### DIFF
--- a/coinbag_flutter/lib/models/tag.dart
+++ b/coinbag_flutter/lib/models/tag.dart
@@ -1,0 +1,7 @@
+class Tag {
+  final String id;
+  final String name;
+  final int colorValue;
+
+  Tag({required this.id, required this.name, required this.colorValue});
+}

--- a/coinbag_flutter/lib/screens/settings/tag_settings_screen.dart
+++ b/coinbag_flutter/lib/screens/settings/tag_settings_screen.dart
@@ -1,31 +1,137 @@
 import 'package:flutter/material.dart';
+import '../../models/tag.dart';
 
-class TagSettingsScreen extends StatelessWidget {
+class TagSettingsScreen extends StatefulWidget {
   const TagSettingsScreen({Key? key}) : super(key: key);
+
+  @override
+  State<TagSettingsScreen> createState() => _TagSettingsScreenState();
+}
+
+class _TagSettingsScreenState extends State<TagSettingsScreen> {
+  final List<Tag> _tags = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
 
   Future<void> _load() async {
     await Future.delayed(const Duration(milliseconds: 500));
+    setState(() {
+      _tags.addAll([
+        Tag(id: '1', name: 'Work', colorValue: Colors.blue.value),
+        Tag(id: '2', name: 'Personal', colorValue: Colors.green.value),
+      ]);
+      _loading = false;
+    });
+  }
+
+  Future<void> _showAddDialog() async {
+    final tag = await showDialog<Tag>(
+      context: context,
+      builder: (context) => const _AddTagDialog(),
+    );
+    if (tag != null) {
+      setState(() => _tags.add(tag));
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<void>(
-      future: _load(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState != ConnectionState.done) {
-          return const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
-          );
-        }
-        final items = List.generate(
-          10,
-          (i) => ListTile(title: Text('Tag ${i + 1}')),
-        );
-        return Scaffold(
-          appBar: AppBar(title: const Text('Tags')),
-          body: ListView(children: items),
-        );
-      },
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Tags')),
+      body: ListView(
+        children: _tags
+            .map(
+              (t) => ListTile(
+                leading: CircleAvatar(backgroundColor: Color(t.colorValue)),
+                title: Text(t.name),
+              ),
+            )
+            .toList(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _showAddDialog,
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+
+class _AddTagDialog extends StatefulWidget {
+  const _AddTagDialog();
+
+  @override
+  State<_AddTagDialog> createState() => _AddTagDialogState();
+}
+
+class _AddTagDialogState extends State<_AddTagDialog> {
+  final _nameController = TextEditingController();
+  final List<Color> _colors = [
+    Colors.red,
+    Colors.orange,
+    Colors.green,
+    Colors.blue,
+    Colors.purple,
+  ];
+  int _selected = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('New Tag'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(labelText: 'Name'),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            children: List.generate(_colors.length, (i) {
+              final color = _colors[i];
+              return GestureDetector(
+                onTap: () => setState(() => _selected = i),
+                child: CircleAvatar(
+                  backgroundColor: color,
+                  child: _selected == i
+                      ? const Icon(Icons.check, color: Colors.white)
+                      : null,
+                ),
+              );
+            }),
+          )
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final name = _nameController.text.trim();
+            if (name.isEmpty) return;
+            final tag = Tag(
+              id: DateTime.now().millisecondsSinceEpoch.toString(),
+              name: name,
+              colorValue: _colors[_selected].value,
+            );
+            Navigator.of(context).pop(tag);
+          },
+          child: const Text('Save'),
+        )
+      ],
     );
   }
 }

--- a/coinbag_flutter/test/ui_test.dart
+++ b/coinbag_flutter/test/ui_test.dart
@@ -5,6 +5,7 @@ import 'package:coinbag_flutter/screens/dashboard_screen.dart';
 import 'package:coinbag_flutter/screens/expenses_list_screen.dart';
 import 'package:coinbag_flutter/screens/add_expense_screen.dart';
 import 'package:coinbag_flutter/screens/account_screen.dart';
+import 'package:coinbag_flutter/screens/settings/tag_settings_screen.dart';
 
 void main() {
   group('Individual screens', () {
@@ -34,6 +35,25 @@ void main() {
       await tester.pumpWidget(const MaterialApp(home: AccountScreen()));
       expect(find.text('Accounts'), findsOneWidget);
       expect(find.text('Login'), findsOneWidget);
+    });
+
+    testWidgets('Tag settings allows creating a tag', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: TagSettingsScreen()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Tags'), findsOneWidget);
+      final initialCount = tester.widgetList(find.byType(ListTile)).length;
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Test');
+      await tester.tap(find.widgetWithIcon(CircleAvatar, Icons.check));
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      final newCount = tester.widgetList(find.byType(ListTile)).length;
+      expect(newCount, initialCount + 1);
     });
   });
 


### PR DESCRIPTION
## Summary
- add Tag model
- implement tag creation in `TagSettingsScreen`
- test tag creation flow in UI tests

## Testing
- `./run_tests.sh` *(fails: Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684047fadb2083209937475b83437ceb